### PR TITLE
Adapt to upstream changes

### DIFF
--- a/examples/rainbow_writer.js
+++ b/examples/rainbow_writer.js
@@ -1,0 +1,93 @@
+/* -*- Mode: JS; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+// SPDX-License-Identifier: MPL-2.0
+"use strict";
+
+//              [     red,   orange,   yellow,    green,     blue,   violet]
+const rainbow = [0xE50000, 0xF08500, 0xFFEE00, 0x008121, 0x004CFF, 0x760188];
+let css, uno_bold, uno_long, uno_font_monospace;
+
+
+function demo() {
+    init_demo();  // run once
+    run_demo();   // run per loaded document
+}
+
+
+function run_demo() {
+    console.log('PLUS: execute example code');
+
+    // Get the currently opened view context.
+    const xModel = Module.jsuno.proxy(Module.getCurrentModelFromViewSh());
+    if (xModel === null) {
+        console.log("No OfficeDocument opened.");
+        return;
+    }
+    const xController = xModel.getCurrentController();
+
+    const xUserInputInterception = css.awt.XUserInputInterception.query(xController);  // TODO: remove
+    const xKeyHandler = new ColorXKeyHandler(xModel);
+    const refXKeyHandler = css.awt.XKeyHandler.reference(css.awt.XKeyHandler.implement(xKeyHandler));
+    xUserInputInterception.addKeyHandler(refXKeyHandler);  // TODO: remove
+    // TODO: xController.addKeyHandler crashes!
+    //xController.addKeyHandler(refXKeyHandler);                // XUserInputInterception.addKeyHandler()
+
+    const xTextCursor = xModel.getText().createTextCursor();  // XTextDocument.getText()
+    xTextCursor.setPropertyValue("CharWeight", uno_bold);     // XPropertySet.setPropertyValue
+    xTextCursor.setString("Please type something!\n\n");
+}
+
+
+function ColorXKeyHandler(xModel) {
+    this.rainbow_i = 0;
+    this.xModel = null;
+    this.refcount = 0;
+    this.acquire = function() { ++this.refcount; };
+    this.release = function() { if (--this.refcount === 0) { this.implXKeyListener.delete(); } };
+    this.keyPressed = function(e) { return false; };
+    this.keyReleased = function(e) {
+        const xController = this.xModel.getCurrentController();
+        const xTextViewCursor = xController.getViewCursor();  // XTextViewCursorSupplier.getViewCursor()
+        const xText = this.xModel.getText();  // XTextDocument.getText()
+        const xTextCursor = xText.createTextCursorByRange(xTextViewCursor.getStart());
+        xTextCursor.goLeft(1, true);
+
+        // Walk the rainbow ;-)
+        const color = new Module.uno_Any(uno_long, rainbow[this.rainbow_i]);
+        this.rainbow_i++;
+        if (this.rainbow_i >= rainbow.length) { this.rainbow_i = 0; }
+
+        xTextCursor.setPropertyValue("CharBackColor", color);  // xPropertySet.setPropertyValue
+        xTextCursor.setPropertyValue("CharWeight", uno_bold);
+        xTextCursor.setPropertyValue("CharFontName", uno_font_monospace);
+        // More properties:
+        //   https://api.libreoffice.org/docs/idl/ref/servicecom_1_1sun_1_1star_1_1style_1_1CharacterProperties.html
+
+        return false;
+    };
+
+    const xModel_types = xModel.getTypes();  // XTypeProvider.getTypes()
+    for (let i=0; i<xModel_types.length; i++) {
+        if (xModel_types[i].toString() == "com.sun.star.text.XTextDocument") {
+            i = xModel_types.length + 1;
+            this.xModel = xModel;
+        }
+    }
+};
+
+
+function init_demo() {
+    css = init_unoembind_uno(Module).com.sun.star;
+    uno_bold = new Module.uno_Any(Module.uno_Type.Float(), css.awt.FontWeight.BOLD);
+    uno_long = Module.uno_Type.Long();
+    uno_font_monospace = new Module.uno_Any(Module.uno_Type.String(), "Monospace");
+}
+
+
+Module.addOnPostRun(function() {
+    console.log('PLUS: wait 10 seconds for LO UI and UNO to settle');
+    setTimeout(function() {  // Waits 10 seconds for UNO.
+        demo();
+    }, 10000);
+});
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */

--- a/examples/simple_key_handler.js
+++ b/examples/simple_key_handler.js
@@ -7,10 +7,97 @@ let css, xModel, xModel_from_component, xController, refXKeyHandler;
 let evtPressed, evtReleased;
 
 
+//TODO: copied from <https://git.libreoffice.org/core> unotest/source/embindtest/embindtest.js for
+// now:
+const unoObject = function(interfaces, obj) {
+    interfaces = ['com.sun.star.lang.XTypeProvider'].concat(interfaces);
+    obj.impl_refcount = 0;
+    obj.impl_types = new Module.uno_Sequence_type(
+        interfaces.length, Module.uno_Sequence.FromSize);
+    for (let i = 0; i !== interfaces.length; ++i) {
+        obj.impl_types.set(i, Module.uno_Type.Interface(interfaces[i]));
+    }
+    obj.impl_implementationId = new Module.uno_Sequence_byte([]);
+    obj.queryInterface = function(type) {
+        for (const i in obj._types) {
+            if (i === type.toString()) {
+                return new Module.uno_Any(
+                    type,
+                    Module['uno_Type_' + i.replace(/\./g, '$')].reference(
+                        obj._impl[obj._types[i]]));
+            }
+        }
+        return new Module.uno_Any(Module.uno_Type.Void(), undefined);
+    };
+    obj.acquire = function() { ++obj.impl_refcount; };
+    obj.release = function() {
+        if (--obj.impl_refcount === 0) {
+            for (const i in obj._impl) {
+                i.delete();
+            }
+            obj.impl_types.delete();
+            obj.impl_implementationId.delete();
+        }
+    };
+    obj.getTypes = function() { return obj.impl_types; };
+    obj.getImplementationId = function() { return obj.impl_implementationId; };
+    obj._impl = {};
+    interfaces.forEach((i) => {
+        obj._impl[i] = Module['uno_Type_' + i.replace(/\./g, '$')].implement(obj);
+    });
+    obj._types = {};
+    const walk = function(td, impl) {
+        const name = td.getName();
+        if (!Object.hasOwn(obj._types, name)) {
+            if (td.getTypeClass() != css.uno.TypeClass.INTERFACE) {
+                throw new Error('not a UNO interface type: ' + name);
+            }
+            obj._types[name] = impl;
+            const bases = css.reflection.XInterfaceTypeDescription2.query(td).getBaseTypes();
+            for (let i = 0; i !== bases.size(); ++i) {
+                walk(bases.get(i), impl)
+            }
+            bases.delete();
+        }
+    };
+    const tdmAny = Module.getUnoComponentContext().getValueByName(
+        '/singletons/com.sun.star.reflection.theTypeDescriptionManager');
+    const tdm = css.container.XHierarchicalNameAccess.query(tdmAny.get());
+    interfaces.forEach((i) => {
+        const td = tdm.getByHierarchicalName(i);
+        walk(css.reflection.XTypeDescription.query(td.get()), i);
+        td.delete();
+    })
+    tdmAny.delete();
+    obj._types['com.sun.star.uno.XInterface'] = 'com.sun.star.lang.XTypeProvider';
+    obj.acquire();
+    return obj;
+};
+
 function demo() {
     console.log('PLUS: execute example code');
 
     css = init_unoembind_uno(Module).com.sun.star;
+
+    /* Implements com.sun.star.awt.XKeyHandler
+     * Outputs printable characters typed into the OfficeDocument.
+     * Browser console is used for output.
+     */
+    const myXKeyHandler = unoObject(
+        ['com.sun.star.awt.XKeyHandler'],
+        {
+            keyPressed(e) {
+                console.log('key pressed (' + e.KeyCode + "): " + e.KeyChar);
+                evtPressed = e;
+                return false;  // false: don't consume (run other event handlers)
+            },
+            keyReleased(e) {
+                console.log('key released (' + e.KeyCode + "): " + e.KeyChar);
+                evtReleased = e;
+                return false;  // false: don't consume (run other event handlers)
+            }
+        });
+
     // Get the currently opened view context.
     // xModel is somethink like: SwXTextDocument, ScModelObj, SdXImpressDocument
     xModel = Module.jsuno.proxy(Module.getCurrentModelFromViewSh());
@@ -20,11 +107,8 @@ function demo() {
     }
     xController = xModel.getCurrentController();
 
-    const xUserInputInterception = css.awt.XUserInputInterception.query(xController);  // TODO: remove
     refXKeyHandler = css.awt.XKeyHandler.reference(css.awt.XKeyHandler.implement(myXKeyHandler));
-    xUserInputInterception.addKeyHandler(refXKeyHandler);  // TODO: remove
-    // TODO: xController.addKeyHandler crashes!
-    //xController.addKeyHandler(refXKeyHandler);  // XUserInputInterception.addKeyHandler()
+    xController.addKeyHandler(refXKeyHandler);
     // addKeyListener != addKeyHandler (that's something very DIFFERENT)
 
     // Disabled, so variables can be accessed from console.
@@ -34,27 +118,6 @@ function demo() {
     // to it. Probably some smart pointer logic.
     //[refXKeyHandler, xController, xModel].forEach((o) => o.delete());
 }
-
-
-/* Implements com.sun.star.awt.XKeyHandler
- * Outputs printable characters typed into the OfficeDocument.
- * Browser console is used for output.
- */
-const myXKeyHandler = {
-    refcount: 0,
-    acquire() { ++this.refcount; },
-    release() { if (--this.refcount === 0) { this.implXKeyListener.delete(); } },
-    keyPressed(e) {
-        console.log('key pressed (' + e.KeyCode + "): " + e.KeyChar);
-        evtPressed = e;
-        return false;  // false: don't consume (run other event handlers)
-    },
-    keyReleased(e) {
-        console.log('key released (' + e.KeyCode + "): " + e.KeyChar);
-        evtReleased = e;
-        return false;  // false: don't consume (run other event handlers)
-    }
-};
 
 
 Module.addOnPostRun(function() {

--- a/examples/simple_key_handler.js
+++ b/examples/simple_key_handler.js
@@ -1,0 +1,67 @@
+/* -*- Mode: JS; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+// SPDX-License-Identifier: MPL-2.0
+"use strict";
+
+// Make variables accessible from the console for debugging.
+let css, xModel, xModel_from_component, xController, refXKeyHandler;
+let evtPressed, evtReleased;
+
+
+function demo() {
+    console.log('PLUS: execute example code');
+
+    css = init_unoembind_uno(Module).com.sun.star;
+    // Get the currently opened view context.
+    // xModel is somethink like: SwXTextDocument, ScModelObj, SdXImpressDocument
+    xModel = Module.jsuno.proxy(Module.getCurrentModelFromViewSh());
+    if (xModel === null) {
+        console.log("No OfficeDocument opened.");
+        return;
+    }
+    xController = xModel.getCurrentController();
+
+    const xUserInputInterception = css.awt.XUserInputInterception.query(xController);  // TODO: remove
+    refXKeyHandler = css.awt.XKeyHandler.reference(css.awt.XKeyHandler.implement(myXKeyHandler));
+    xUserInputInterception.addKeyHandler(refXKeyHandler);  // TODO: remove
+    // TODO: xController.addKeyHandler crashes!
+    //xController.addKeyHandler(refXKeyHandler);  // XUserInputInterception.addKeyHandler()
+    // addKeyListener != addKeyHandler (that's something very DIFFERENT)
+
+    // Disabled, so variables can be accessed from console.
+    // Embind-3.1.56 does this if the variables are locally scoped, but
+    // warns it's not reliable.
+    // Seems not actually to delete the object if there are other references
+    // to it. Probably some smart pointer logic.
+    //[refXKeyHandler, xController, xModel].forEach((o) => o.delete());
+}
+
+
+/* Implements com.sun.star.awt.XKeyHandler
+ * Outputs printable characters typed into the OfficeDocument.
+ * Browser console is used for output.
+ */
+const myXKeyHandler = {
+    refcount: 0,
+    acquire() { ++this.refcount; },
+    release() { if (--this.refcount === 0) { this.implXKeyListener.delete(); } },
+    keyPressed(e) {
+        console.log('key pressed (' + e.KeyCode + "): " + e.KeyChar);
+        evtPressed = e;
+        return false;  // false: don't consume (run other event handlers)
+    },
+    keyReleased(e) {
+        console.log('key released (' + e.KeyCode + "): " + e.KeyChar);
+        evtReleased = e;
+        return false;  // false: don't consume (run other event handlers)
+    }
+};
+
+
+Module.addOnPostRun(function() {
+    console.log('PLUS: wait 10 seconds for LO UI and UNO to settle');
+    setTimeout(function() {  // Waits 10 seconds for UNO.
+        demo();
+    }, 10000);
+});
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */

--- a/source/jsuno.js
+++ b/source/jsuno.js
@@ -38,7 +38,7 @@ Module.jsuno = {
 
     translateToEmbind: function(obj, type, toDelete) {
         switch (type.getTypeClass()) {
-        case Module.uno.com.sun.star.uno.TypeClass.ANY:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.ANY:
             if ('type' in obj && obj.type instanceof Module.uno_Type && 'val' in obj) {
                 const any = new Module.uno_Any(
                     obj.type, Module.jsuno.translateToEmbind(obj.val, obj.type, toDelete));
@@ -46,7 +46,7 @@ Module.jsuno = {
                 return any;
             }
             break;
-        case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.SEQUENCE:
             if (Array.isArray(obj)) {
                 const ctype = type.getSequenceComponentType();
                 const seq = new (Module.jsuno.getEmbindSequenceCtor(ctype))(
@@ -58,7 +58,7 @@ Module.jsuno = {
                 return seq;
             }
             break;
-        case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.INTERFACE:
             if (obj !== null && type.toString() !== 'com.sun.star.uno.XInterface') {
                 const target = obj[Module.jsuno.getProxyTarget];
                 const handle = target === undefined ? obj : target;
@@ -86,7 +86,7 @@ Module.jsuno = {
             let fromType;
             let val;
             const toDelete = [];
-            if (type.getTypeClass() === Module.uno.com.sun.star.uno.TypeClass.ANY) {
+            if (type.getTypeClass() === init_unoembind_uno(Module).com.sun.star.uno.TypeClass.ANY) {
                 switch (typeof obj) {
                 case 'undefined':
                     fromType = Module.uno_Type.Void();
@@ -145,12 +145,12 @@ Module.jsuno = {
 
     translateFromEmbind: function(val, type) {
         switch (type.getTypeClass()) {
-        case Module.uno.com.sun.star.uno.TypeClass.BOOLEAN:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.BOOLEAN:
             return Boolean(val);
-        case Module.uno.com.sun.star.uno.TypeClass.ANY:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.ANY:
             return {type: val.getType(),
                     val: Module.jsuno.translateFromEmbind(val.get(), val.getType())};
-        case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.SEQUENCE:
             {
                 const arr = [];
                 for (let i = 0; i !== val.size(); ++i) {
@@ -163,7 +163,7 @@ Module.jsuno = {
                 }
                 return arr;
             }
-        case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+        case init_unoembind_uno(Module).com.sun.star.uno.TypeClass.INTERFACE:
             return Module.jsuno.proxy(val);
         default:
             return val;
@@ -171,7 +171,7 @@ Module.jsuno = {
     },
 
     translateFromAny: function(any, type) {
-        if (type.getTypeClass() === Module.uno.com.sun.star.uno.TypeClass.ANY) {
+        if (type.getTypeClass() === init_unoembind_uno(Module).com.sun.star.uno.TypeClass.ANY) {
             return {type: any.getType(),
                     val: Module.jsuno.translateFromEmbind(any.get(), any.getType())};
         } else {
@@ -197,8 +197,8 @@ Module.jsuno = {
         const arg = new Module.uno_Any(
             Module.uno_Type.Interface('com.sun.star.uno.XInterface'), unoObject);
         const args = new Module.uno_Sequence_any([arg]);
-        const invoke = Module.uno.com.sun.star.script.XInvocation2.query(
-            Module.uno.com.sun.star.script.Invocation.create(
+        const invoke = init_unoembind_uno(Module).com.sun.star.script.XInvocation2.query(
+            init_unoembind_uno(Module).com.sun.star.script.Invocation.create(
                 Module.getUnoComponentContext()).createInstanceWithArguments(args));
         arg.delete();
         args.delete();
@@ -221,7 +221,7 @@ Module.jsuno = {
                         const deleteArgs = [];
                         for (let i = 0; i !== info.aParamTypes.size(); ++i) {
                             switch (info.aParamModes.get(i)) {
-                            case Module.uno.com.sun.star.reflection.ParamMode.IN:
+                            case init_unoembind_uno(Module).com.sun.star.reflection.ParamMode.IN:
                                 {
                                     const {any, owning} = Module.jsuno.translateToAny(
                                         arguments[i], info.aParamTypes.get(i));
@@ -231,11 +231,11 @@ Module.jsuno = {
                                     }
                                     break;
                                 }
-                            case Module.uno.com.sun.star.reflection.ParamMode.INOUT:
+                            case init_unoembind_uno(Module).com.sun.star.reflection.ParamMode.INOUT:
                                 if (Module.jsuno.isEmbindInOutParam(arguments[i])) {
                                     const val = arguments[i].val;
                                     if (info.aParamTypes.get(i).getTypeClass()
-                                        === Module.uno.com.sun.star.uno.TypeClass.ANY)
+                                        === init_unoembind_uno(Module).com.sun.star.uno.TypeClass.ANY)
                                     {
                                         args.set(i, val);
                                         val.delete();
@@ -289,7 +289,7 @@ Module.jsuno = {
                             if (Module.jsuno.isEmbindInOutParam(arguments[j])) {
                                 const val = outparam.get(i);
                                 if (info.aParamTypes.get(j).getTypeClass()
-                                    === Module.uno.com.sun.star.uno.TypeClass.ANY)
+                                    === init_unoembind_uno(Module).com.sun.star.uno.TypeClass.ANY)
                                 {
                                     arguments[j].val = val;
                                 } else {
@@ -334,7 +334,7 @@ Module.jsuno = {
                 if (invoke.hasProperty(prop)) {
                     const info = invoke.getInfoForName(prop, true);
                     if (info.PropertyAttribute
-                        & Module.uno.com.sun.star.beans.PropertyAttribute.READONLY)
+                        & init_unoembind_uno(Module).com.sun.star.beans.PropertyAttribute.READONLY)
                     {
                         throw new Error('set readonly property ' + prop);
                     }
@@ -363,5 +363,15 @@ Module.jsuno = {
         });
     },
 };
+
+Module.addOnPostRun = function(block) {
+    console.log('PLUS: poll and wait for Embind "Module"');  // not needed for QT5
+    const interval = setInterval(function() {
+        console.log('looping');
+        if (typeof Module === 'undefined') return;
+        clearInterval(interval);
+        block();
+    }, 0.1);
+}
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */


### PR DESCRIPTION
* <https://gerrit.libreoffice.org/c/core/+/168700> "Embind: Centrally initialize via Module.initUno() in a new uno.js"
* <https://gerrit.libreoffice.org/c/core/+/168732> "Embind: Let unoObject return a css.uno.XInterface reference"