### PR TITLE
Let zetajs return unwrapped ANY representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,7 @@ With zetajs:
 const css = zetajs.uno.com.sun.star;
 const desktop = css.frame.Desktop.create(zetajs.getUnoComponentContext());
 let xModel = desktop.getCurrentFrame().getController().getModel();
-if (xModel === null
-    || !zetajs.fromAny(
-        xModel.queryInterface(zetajs.type.interface(css.text.XTextDocument))))
-{
+if (!xModel?.queryInterface(zetajs.type.interface(css.text.XTextDocument))) {
     xModel = desktop.loadComponentFromURL(
         'file:///android/default-document/example.odt', '_default', 0, []);
 }
@@ -90,8 +87,7 @@ With zetajs:
 ```javascript
 const xText = xModel.getText();
 const xParaEnumeration = xText.createEnumeration();
-for (const next of xParaEnumeration) {
-    const xParagraph = zetajs.fromAny(next);
+for (const xParagraph of xParaEnumeration) {
     const color = Math.floor(Math.random() * 0xFFFFFF);
     xParagraph.setPropertyValue("CharColor", color);
 }

--- a/docs/start.md
+++ b/docs/start.md
@@ -108,7 +108,7 @@ That `zetajs` object has certain properties:
 
 - `zetajs.mainPort` is used for [communication between threads](#communication-between-threads).
 
-See [The zetajs UNO Mapping](uno.html) for further documentation of the mapping between zetajs and UNO.
+See [The zetajs UNO Mapping](uno.html) for further documentation of the mapping between zetajs and UNO.  Whenver a value of UNO type `ANY` is returned from zetajs, the unwrapped repsresentation will be used.  However, for situations that need to preserve the exact contained type of a returned value of UNO type `ANY`, each zetajs representation of a UNO object has a `$precise` property.  For UNO calls made through such a `$precise` property, whenever a value of UNO type `ANY` is returned, the wrapped repsresentation will be used.
 
 ## Communication Between Threads
 

--- a/docs/uno.md
+++ b/docs/uno.md
@@ -32,11 +32,23 @@ The mapping between [UNO types](http://www.openoffice.org/udk/common/man/typesys
 
 - UNO `ANY` maps to the combined set of wrapped and unwrapped representations:
 
-    - Any value of UNO type `ANY` can map to a wrapped representation, which is an opaque JavaScript object that has a `type` property (containing a zetajs representation of a value of UNO type `TYPE`) and a `val` property (containing a zetajs representation of a value of the given UNO type).
+    - Any value of UNO type `ANY` can map to and from a wrapped representation, which is an opaque JavaScript object that has a `type` property (containing a zetajs representation of a value of UNO type `TYPE`) and a `val` property (containing a zetajs representation of a value of the given UNO type).
 
-    - A value of UNO type `ANY` where the contained UNO value is of any of the UNO types `VOID`, `BOOLEAN`, `LONG`, `HYPER`, `STRING`, `TYPE`, a UNO enum type, a UNO struct type, or a UNO exception type, can also be mapped to an unwrapped representation, which directly maps to the JavaScript representation of the contained UNO value.
+    - A value of UNO type `ANY` where the contained UNO value is of any of the UNO types `VOID`, `BOOLEAN`, `LONG`, `HYPER`, `STRING`, `TYPE`, a UNO enum type, a UNO struct type, or a UNO exception type, can also map to and from an unwrapped representation, which directly maps to the JavaScript representation of the contained UNO value.
 
-    See the documentation of `zetajs.Any` and `zetajs.fromAny` at [Starting Points: Using zetajs](start.html#using-zetajs).
+    - A value of UNO type `ANY` where the contained UNO value is of any of the UNO types `BYTE`, `SHORT`, `UNSIGNED SHORT`, `UNSIGNED LONG`, `UNSIGNED HYPER`, `FLOAT`, `DOUBLE`, `CHAR`, a UNO sequence type, or a UNO interface type, can also map to an unwrapped representation, which directly maps to the JavaScript representation of the contained UNO value.  In the opposite direction:
+
+        - JavaScript Number values with integer values in the interval 2<sup>63</sup> (inclusive) to 2<sup>64</sup> (exclusive) map to UNO `ANY` values with contained values of UNO type `UNSIGNED LONG`.
+
+        - JavaScript Number values not covered by the preceding cases for `LONG` and `UNSIGNED LONG` target types map to UNO `ANY` values with contained values of UNO type `DOUBLE`.
+
+        - JavaScript BigInt values that are larger than 2<sup>63</sup>&nbsp;&minus;&nbsp;1 map to UNO `ANY` values with contained values of UNO type `UNSIGNED HYPER`.
+
+        - JavaScript Array values map to UNO `ANY` values with contained values of UNO type &ldquo;sequence of `ANY`&rdquo;.
+
+        - JavaScript Null values and JavaScript objects representing UNO objects map to UNO `ANY` values with contained values of UNO interface type `com.sun.star.uno.XInterface`.
+
+    Also see the documentation of `zetajs.Any`, `zetajs.getAnyType`, and `zetajs.fromAny` at [Starting Points: Using zetajs](start.html#using-zetajs).
 
 - UNO sequence types map to JavaScript Arrays with corresponding element value constraints, up to the JavaScript length limit of 2<sup>32</sup>&minus;1 elements.
 

--- a/examples/TableSample.js
+++ b/examples/TableSample.js
@@ -17,7 +17,7 @@ Module.zetajs.then(function(zetajs) {
     table.setPropertyValue('BackTransparent', false);
     table.setPropertyValue('BackColor', 13421823);
     const rows = table.getRows();
-    const row = zetajs.fromAny(rows.getByIndex(0));
+    const row = rows.getByIndex(0);
     row.setPropertyValue('BackTransparent', false);
     row.setPropertyValue('BackColor', 6710932);
     const insertTextIntoCell = function(cellName, text, color) {

--- a/examples/convertpdf/convertpdf.js
+++ b/examples/convertpdf/convertpdf.js
@@ -23,8 +23,7 @@ Module.zetajs.then(function(argZetajs) {
             try {
                 // Close old doc in advance. Keep doc open afterwards for debugging.
                 if (doc !== undefined &&
-                    zetajs.fromAny(doc.queryInterface(zetajs.type.interface(css.util.XCloseable)))
-                        !== undefined) {
+                    doc.queryInterface(zetajs.type.interface(css.util.XCloseable))) {
                     doc.close(false);
                 }
                 from = e.data.from;
@@ -34,7 +33,7 @@ Module.zetajs.then(function(argZetajs) {
                 zetajs.mainPort.postMessage({cmd: 'converted', name: e.data.name, from, to});
             } catch (e) {
                 const exc = zetajs.catchUnoException(e);
-                console.log('TODO', zetajs.getAnyType(exc), zetajs.fromAny(exc).Message);
+                console.log('TODO', zetajs.getAnyType(exc), exc.Message);
             }
             break;
         default:

--- a/examples/ping-monitor/office_thread.js
+++ b/examples/ping-monitor/office_thread.js
@@ -24,12 +24,11 @@ function demo() {
 
     // Turn off toolbars:
     const config = css.configuration.ReadWriteAccess.create(context, 'en-US')
-    const uielems = zetajs.fromAny(
-        config.getByHierarchicalName(
-            '/org.openoffice.Office.UI.CalcWindowState/UIElements/States'));
+    const uielems = config.getByHierarchicalName(
+        '/org.openoffice.Office.UI.CalcWindowState/UIElements/States');
     for (const i of uielems.getElementNames()) {
-        const uielem = zetajs.fromAny(uielems.getByName(i));
-        if (zetajs.fromAny(uielem.getByName('Visible'))) {
+        const uielem = uielems.getByName(i);
+        if (uielem.getByName('Visible')) {
             uielem.setPropertyValue('Visible', false);
         }
     }

--- a/examples/rainbow_writer.js
+++ b/examples/rainbow_writer.js
@@ -5,14 +5,13 @@
 
 //              [     red,   orange,   yellow,    green,     blue,   violet]
 const rainbow = [0xE50000, 0xF08500, 0xFFEE00, 0x008121, 0x004CFF, 0x760188];
-let zetajs, css, uno_bold, uno_long, uno_font_monospace;
+let zetajs, css, uno_bold, uno_font_monospace;
 
 
 function demo() {
     console.log('PLUS: execute example code');
 
-    uno_bold = new zetajs.Any(zetajs.type.float, css.awt.FontWeight.BOLD);
-    uno_long = zetajs.type.long;
+    uno_bold = css.awt.FontWeight.BOLD;
     uno_font_monospace = "Monospace";
 
     // Open a new writer document.
@@ -43,7 +42,7 @@ function ColorXKeyHandler(xModel) {
         xTextCursor.goLeft(1, true);
 
         // Walk the rainbow ;-)
-        const color = new zetajs.Any(uno_long, rainbow[this.rainbow_i]);
+        const color = rainbow[this.rainbow_i];
         this.rainbow_i++;
         if (this.rainbow_i >= rainbow.length) { this.rainbow_i = 0; }
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -9,10 +9,7 @@ Module.zetajs.then(function(zetajs) {
         const css = zetajs.uno.com.sun.star;
         const desktop = css.frame.Desktop.create(zetajs.getUnoComponentContext());
         let xModel = desktop.getCurrentFrame().getController().getModel();
-        if (xModel === null
-            || !zetajs.fromAny(
-                xModel.queryInterface(zetajs.type.interface(css.text.XTextDocument))))
-        {
+        if (!xModel?.queryInterface(zetajs.type.interface(css.text.XTextDocument))) {
             xModel = desktop.loadComponentFromURL(
                 'file:///android/default-document/example.odt', '_default', 0, []);
         }
@@ -28,8 +25,7 @@ Module.zetajs.then(function(zetajs) {
         const xModel = getTextDocument();
         const xText = xModel.getText();
         const xParaEnumeration = xText.createEnumeration();
-        for (const next of xParaEnumeration) {
-            const xParagraph = zetajs.fromAny(next);
+        for (const xParagraph of xParaEnumeration) {
             const color = Math.floor(Math.random() * 0xFFFFFF);
             xParagraph.setPropertyValue("CharColor", color);
         }

--- a/examples/standalone/index.js
+++ b/examples/standalone/index.js
@@ -15,12 +15,11 @@ function demo() {
 
     // Turn off toolbars:
     const config = css.configuration.ReadWriteAccess.create(context, 'en-US')
-    const uielems = zetajs.fromAny(
-        config.getByHierarchicalName(
-            '/org.openoffice.Office.UI.WriterWindowState/UIElements/States'));
+    const uielems = config.getByHierarchicalName(
+        '/org.openoffice.Office.UI.WriterWindowState/UIElements/States');
     for (const i of uielems.getElementNames()) {
-        const uielem = zetajs.fromAny(uielems.getByName(i));
-        if (zetajs.fromAny(uielem.getByName('Visible'))) {
+        const uielem = uielems.getByName(i);
+        if (uielem.getByName('Visible')) {
             uielem.setPropertyValue('Visible', false);
         }
     }
@@ -83,7 +82,7 @@ function button(id, url) {
     const listener = zetajs.unoObject([css.frame.XStatusListener], {
         disposing: function(source) {},
         statusChanged: function(state) {
-            zetajs.mainPort.postMessage({cmd: 'state', id, state: zetajs.fromAny(state.State)});
+            zetajs.mainPort.postMessage({cmd: 'state', id, state: state.State});
         }
     });
     queryDispatch(urlObj).addStatusListener(listener, urlObj);

--- a/examples/vuejs3-ping-tool/public/office_thread.js
+++ b/examples/vuejs3-ping-tool/public/office_thread.js
@@ -22,12 +22,11 @@ function demo() {
 
     // Turn off toolbars:
     const config = css.configuration.ReadWriteAccess.create(context, 'en-US')
-    const uielems = zetajs.fromAny(
-        config.getByHierarchicalName(
-            '/org.openoffice.Office.UI.CalcWindowState/UIElements/States'));
+    const uielems = config.getByHierarchicalName(
+        '/org.openoffice.Office.UI.CalcWindowState/UIElements/States');
     for (const i of uielems.getElementNames()) {
-        const uielem = zetajs.fromAny(uielems.getByName(i));
-        if (zetajs.fromAny(uielem.getByName('Visible'))) {
+        const uielem = uielems.getByName(i);
+        if (uielem.getByName('Visible')) {
             uielem.setPropertyValue('Visible', false);
         }
     }
@@ -61,7 +60,7 @@ function demo() {
     doc = desktop.loadComponentFromURL('file:///tmp/calc_ping_example.ods', '_default', 0, []);
     ctrl = doc.getCurrentController();
     xComponent = ctrl.getModel();
-    charLocale = zetajs.fromAny(xComponent.getPropertyValue('CharLocale'));
+    charLocale = xComponent.getPropertyValue('CharLocale');
     formatNumber = xComponent.getNumberFormats().
         queryKey('0', charLocale, false);
     formatText = xComponent.getNumberFormats().
@@ -130,7 +129,7 @@ function button(id, url) {
     const listener = zetajs.unoObject([css.frame.XStatusListener], {
         disposing: function(source) {},
         statusChanged: function(state) {
-            zetajs.mainPort.postMessage({cmd: 'state', id, state: zetajs.fromAny(state.State)});
+            zetajs.mainPort.postMessage({cmd: 'state', id, state: state.State});
         }
     });
     queryDispatch(urlObj).addStatusListener(listener, urlObj);

--- a/source/zeta.js
+++ b/source/zeta.js
@@ -11,6 +11,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
             value.forEach((val) => val.delete());
         });
         const getProxyTarget = Symbol('getProxyTarget');
+        const keepAlive = Symbol('keepAlive');
         function gcWrap(obj) {
             // Embind has already registered obj at some FinalizationRegistry that prints the
             // "Embind found a leaked C++ instance" warning, which we want to suppress; and if we
@@ -222,7 +223,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
                 type.delete();
             }
         };
-        function translateFromEmbind(val, type, cleanUpVal) {
+        function translateFromEmbind(val, type, precise, cleanUpVal) {
             switch (type.getTypeClass()) {
             case Module.uno.com.sun.star.uno.TypeClass.BOOLEAN:
                 return Boolean(val);
@@ -231,20 +232,22 @@ Module.zetajs = new Promise(function (resolve, reject) {
             case Module.uno.com.sun.star.uno.TypeClass.ANY:
                 {
                     const ty = gcWrap(val.getType());
+                    let v;
                     try {
-                        return new Any(ty, translateFromEmbind(val.get(), ty, cleanUpVal));
+                        v = translateFromEmbind(val.get(), ty, precise, cleanUpVal);
                     } finally {
                         if (cleanUpVal) {
                             val.delete();
                         }
                     }
+                    return precise ? new Any(ty, v) : v;
                 }
             case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
                 {
                     const td = type.getSequenceComponentType();
                     const arr = [];
                     for (let i = 0; i !== val.size(); ++i) {
-                        arr.push(translateFromEmbind(val.get(i), td, cleanUpVal));
+                        arr.push(translateFromEmbind(val.get(i), td, precise, cleanUpVal));
                     }
                     if (cleanUpVal) {
                         val.delete();
@@ -277,7 +280,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
                         for (let i = 0; i !== types.size(); ++i) {
                             const name = names.get(i);
                             const td = translateTypeDescriptionAndDelete(types.get(i));
-                            obj[name] = translateFromEmbind(val[name], td, cleanUpVal);
+                            obj[name] = translateFromEmbind(val[name], td, precise, cleanUpVal);
                             td.delete();
                         }
                         types.delete();
@@ -301,18 +304,18 @@ Module.zetajs = new Promise(function (resolve, reject) {
                 return val;
             }
         };
-        function translateFromAny(any, type) {
+        function translateFromAny(any, type, precise) {
             if (type.getTypeClass() === Module.uno.com.sun.star.uno.TypeClass.ANY) {
-                return translateFromEmbind(any, type, false);
+                return translateFromEmbind(any, type, precise, false);
             } else {
                 const td = any.getType();
-                const val = translateFromEmbind(any.get(), td, true);
+                const val = translateFromEmbind(any.get(), td, precise, true);
                 td.delete();
                 return val;
             }
         };
-        function translateFromAnyAndDelete(any, type) {
-            const val = translateFromAny(any, type);
+        function translateFromAnyAndDelete(any, type, precise) {
+            const val = translateFromAny(any, type, precise);
             any.delete();
             return val;
         };
@@ -324,6 +327,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
             const toDelete = [unoObject];
             Module.uno$zetajs_deleteRegistry.register(prox, toDelete);
             prox[getProxyTarget] = unoObject;
+            prox.$precise = {[getProxyTarget]: unoObject, [keepAlive]: prox};
             // css.script.XInvocation2::getInfo invents additional members (e.g., an attribute "Foo"
             // if there is a method "getFoo"), so better determine the actual set of members via
             // css.lang.XTypeProvider::getTypes:
@@ -343,7 +347,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
                 const invoke = Module.uno.com.sun.star.script.XInvocation2.query(inst);
                 inst.delete();
                 toDelete.push(invoke);
-                function invokeMethod(name, args) {
+                function invokeMethod(name, args, precise) {
                     const info = invoke.getInfoForName(name, true);
                     try {
                         if (args.length != info.aParamTypes.size()) {
@@ -390,9 +394,9 @@ Module.zetajs = new Promise(function (resolve, reject) {
                             if (getAnyType(exc) ==
                                 'com.sun.star.reflection.InvocationTargetException')
                             {
-                                throwUnoException(fromAny(fromAny(exc).TargetException));
+                                throwUnoException(exc.TargetException);
                             } else {
-                                throwUnoException(fromAny(exc));
+                                throwUnoException(exc);
                             }
                         } finally {
                             deleteArgs.forEach((arg) => arg.delete());
@@ -405,23 +409,23 @@ Module.zetajs = new Promise(function (resolve, reject) {
                         for (let i = 0; i !== outparamindex.size(); ++i) {
                             const j = outparamindex.get(i);
                             const ty = info.aParamTypes.get(j);
-                            args[j].val = translateFromAnyAndDelete(outparam.get(i), ty);
+                            args[j].val = translateFromAnyAndDelete(outparam.get(i), ty, precise);
                             ty.delete();
                         }
                         outparamindex.delete();
                         outparam.delete();
-                        return translateFromAnyAndDelete(ret, info.aType);
+                        return translateFromAnyAndDelete(ret, info.aType, precise);
                     } finally {
                         info.aType.delete();
                         info.aParamTypes.delete();
                         info.aParamModes.delete();
                     }
                 };
-                function invokeGetter(name) {
+                function invokeGetter(name, precise) {
                     const info = invoke.getInfoForName(name, true);
                     try {
                         const ret = invoke.getValue(name);
-                        return translateFromAnyAndDelete(ret, info.aType);
+                        return translateFromAnyAndDelete(ret, info.aType, precise);
                     } finally {
                         info.aType.delete();
                         info.aParamTypes.delete();
@@ -444,7 +448,9 @@ Module.zetajs = new Promise(function (resolve, reject) {
                     }
                 };
                 prox.queryInterface = function() {
-                    return invokeMethod('queryInterface', arguments); };
+                    return invokeMethod('queryInterface', arguments, false); };
+                prox.$precise.queryInterface = function() {
+                    return invokeMethod('queryInterface', arguments, true); };
                 const seen = {'com.sun.star.uno.XInterface': true};
                 function walk(td) {
                     const iname = td.getName();
@@ -472,13 +478,24 @@ Module.zetajs = new Promise(function (resolve, reject) {
                             if (atd !== null) {
                                 Object.defineProperty(prox, name, {
                                     enumerable: true,
-                                    get() { return invokeGetter(name); },
+                                    get() { return invokeGetter(name, false); },
+                                    set: atd.isReadOnly()
+                                        ? undefined
+                                        : function(value) { return invokeSetter(name, value); }});
+                                Object.defineProperty(prox.$precise, name, {
+                                    enumerable: true,
+                                    get() { return invokeGetter(name, true); },
                                     set: atd.isReadOnly()
                                         ? undefined
                                         : function(value) { return invokeSetter(name, value); }});
                                 atd.delete();
                             } else {
-                                prox[name] = function() { return invokeMethod(name, arguments); };
+                                prox[name] = function() {
+                                    return invokeMethod(name, arguments, false);
+                                };
+                                prox.$precise[name] = function() {
+                                    return invokeMethod(name, arguments, true);
+                                };
                             }
                         }
                         itd.delete();
@@ -487,6 +504,11 @@ Module.zetajs = new Promise(function (resolve, reject) {
                             prox[Symbol.iterator] = function*() {
                                 while (prox.hasMoreElements()) {
                                     yield prox.nextElement();
+                                }
+                            }
+                            prox.$precise[Symbol.iterator] = function*() {
+                                while (prox.$precise.hasMoreElements()) {
+                                    yield prox.$precise.nextElement();
                                 }
                             }
                         }
@@ -516,7 +538,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
                 const any = context.getValueByName('/singletons/' + name);
                 if (getAnyType(any).getTypeClass() !==
                         Module.uno.com.sun.star.uno.TypeClass.INTERFACE
-                    || fromAny(any) === null)
+                    || any === null)
                 {
                     throwUnoException(
                         new uno.com.sun.star.uno.DeploymentException(
@@ -994,7 +1016,8 @@ Module.zetajs = new Promise(function (resolve, reject) {
                                 if (!atd.isReadOnly()) {
                                     wrapper['set' + aname] = function() {
                                         obj['set' + aname].apply(
-                                            obj, [translateFromEmbind(arguments[0], type, false)]);
+                                            obj,
+                                            [translateFromEmbind(arguments[0], type, true, false)]);
                                     };
                                 }
                                 atd.delete();
@@ -1026,11 +1049,11 @@ Module.zetajs = new Promise(function (resolve, reject) {
                                             arg = {};
                                             if (params[i].dirIn) {
                                                 arg.val = translateFromEmbind(
-                                                    arguments[i].val, params[i].type, false);
+                                                    arguments[i].val, params[i].type, true, false);
                                             }
                                         } else {
                                             arg = translateFromEmbind(
-                                                arguments[i], params[i].type, false);
+                                                arguments[i], params[i].type, true, false);
                                         }
                                         args.push(arg);
                                     }

--- a/test/smoketest.js
+++ b/test/smoketest.js
@@ -96,7 +96,7 @@ Module.zetajs.then(function(zetajs) {
         console.assert(v.m11 === 'Ö');
         console.assert(v.m12 === 'hä');
         console.assert(v.m13.toString() === 'long');
-        console.assert(zetajs.fromAny(v.m14) === -123456);
+        console.assert(v.m14 === -123456);
         console.assert(v.m15.length === 3);
         console.assert(v.m15[0] === 'foo');
         console.assert(v.m15[1] === 'barr');
@@ -105,7 +105,7 @@ Module.zetajs.then(function(zetajs) {
         console.assert(v.m17.m === -123456);
         console.assert(v.m18.m1.m === 'foo');
         console.assert(v.m18.m2 === -123456);
-        console.assert(zetajs.fromAny(v.m18.m3) === -123456);
+        console.assert(v.m18.m3 === -123456);
         console.assert(v.m18.m4.m === 'barr');
         console.assert(zetajs.sameUnoObject(v.m19, test));
         console.assert(
@@ -144,13 +144,13 @@ Module.zetajs.then(function(zetajs) {
         console.assert(def.m11 === '\0');
         console.assert(def.m12 === '');
         console.assert(def.m13.toString() === 'void');
-        console.assert(zetajs.fromAny(def.m14) === undefined);
+        console.assert(def.m14 === undefined);
         console.assert(def.m15.length === 0);
         console.assert(def.m16 === zetajs.uno.org.libreoffice.embindtest.Enum.E_10);
         console.assert(def.m17.m === 0);
         console.assert(def.m18.m1.m === '');
         console.assert(def.m18.m2 === 0);
-        console.assert(zetajs.fromAny(def.m18.m3) === undefined);
+        console.assert(def.m18.m3 === undefined);
         console.assert(def.m18.m4.m === '');
         console.assert(def.m19 === null);
     }
@@ -158,7 +158,7 @@ Module.zetajs.then(function(zetajs) {
         const v = test.getTemplate();
         console.assert(v.m1.m === 'foo');
         console.assert(v.m2 === -123456);
-        console.assert(zetajs.fromAny(v.m3) === -123456);
+        console.assert(v.m3 === -123456);
         console.assert(v.m4.m === 'barr');
         console.assert(
             test.isTemplate(
@@ -173,35 +173,35 @@ Module.zetajs.then(function(zetajs) {
             zetajs.type.struct(zetajs.uno.org.libreoffice.embindtest.StructString)]);
         console.assert(def.m1.m === '');
         console.assert(def.m2 === 0);
-        console.assert(zetajs.fromAny(def.m3) === undefined);
+        console.assert(def.m3 === undefined);
         console.assert(def.m4.m === '');
     }
     {
         const v = test.getAnyVoid();
-        console.assert(zetajs.fromAny(v) === undefined);
+        console.assert(v === undefined);
         console.assert(test.isAnyVoid(v));
         console.assert(test.isAnyVoid(undefined));
     }
     {
         const v = test.getAnyBoolean();
-        console.assert(zetajs.fromAny(v) === true);
+        console.assert(v === true);
         console.assert(test.isAnyBoolean(v));
         console.assert(test.isAnyBoolean(true));
     }
     {
-        const v = test.getAnyByte();
+        const v = test.$precise.getAnyByte();
         console.assert(zetajs.fromAny(v) === -12);
         console.assert(test.isAnyByte(v));
         console.assert(test.isAnyByte(new zetajs.Any(zetajs.type.byte, -12)));
     }
     {
-        const v = test.getAnyShort();
+        const v = test.$precise.getAnyShort();
         console.assert(zetajs.fromAny(v) === -1234);
         console.assert(test.isAnyShort(v));
         console.assert(test.isAnyShort(new zetajs.Any(zetajs.type.short, -1234)));
     }
     {
-        const v = test.getAnyUnsignedShort();
+        const v = test.$precise.getAnyUnsignedShort();
         console.assert(zetajs.fromAny(v) === 54321);
         console.assert(test.isAnyUnsignedShort(v));
         console.assert(test.isAnyUnsignedShort(new zetajs.Any(zetajs.type.unsigned_short, 54321)));
@@ -213,56 +213,56 @@ Module.zetajs.then(function(zetajs) {
         console.assert(test.isAnyLong(-123456));
     }
     {
-        const v = test.getAnyUnsignedLong();
+        const v = test.$precise.getAnyUnsignedLong();
         console.assert(zetajs.fromAny(v) === 3456789012);
         console.assert(test.isAnyUnsignedLong(v));
         console.assert(test.isAnyUnsignedLong(3456789012));
     }
     {
         const v = test.getAnyHyper();
-        console.assert(zetajs.fromAny(v) === -123456789n);
+        console.assert(v === -123456789n);
         console.assert(test.isAnyHyper(v));
         console.assert(test.isAnyHyper(-123456789n));
     }
     {
-        const v = test.getAnyUnsignedHyper();
+        const v = test.$precise.getAnyUnsignedHyper();
         console.assert(zetajs.fromAny(v) === 9876543210n);
         console.assert(test.isAnyUnsignedHyper(v));
         console.assert(test.isAnyUnsignedHyper(
             new zetajs.Any(zetajs.type.unsigned_hyper, 9876543210n)));
     }
     {
-        const v = test.getAnyFloat();
+        const v = test.$precise.getAnyFloat();
         console.assert(zetajs.fromAny(v) === -10.25);
         console.assert(test.isAnyFloat(v));
         console.assert(test.isAnyFloat(new zetajs.Any(zetajs.type.float, -10.25)));
     }
     {
         const v = test.getAnyDouble();
-        console.assert(zetajs.fromAny(v) === 100.5);
+        console.assert(v === 100.5);
         console.assert(test.isAnyDouble(v));
         console.assert(test.isAnyDouble(100.5));
     }
     {
-        const v = test.getAnyChar();
+        const v = test.$precise.getAnyChar();
         console.assert(zetajs.fromAny(v) === 'Ö');
         console.assert(test.isAnyChar(v));
         console.assert(test.isAnyChar(new zetajs.Any(zetajs.type.char, 'Ö')));
     }
     {
         const v = test.getAnyString();
-        console.assert(zetajs.fromAny(v) === 'hä');
+        console.assert(v === 'hä');
         console.assert(test.isAnyString(v));
         console.assert(test.isAnyString('hä'));
     }
     {
         const v = test.getAnyType();
-        console.assert(zetajs.fromAny(v).toString() === 'long');
+        console.assert(v.toString() === 'long');
         console.assert(test.isAnyType(v));
         console.assert(test.isAnyType(zetajs.type.long));
     }
     {
-        const v = test.getAnySequence();
+        const v = test.$precise.getAnySequence();
         console.assert(zetajs.fromAny(v).length === 3);
         console.assert(zetajs.fromAny(v)[0] === 'foo');
         console.assert(zetajs.fromAny(v)[1] === 'barr');
@@ -284,37 +284,37 @@ Module.zetajs.then(function(zetajs) {
     }
     {
         const v = test.getAnyEnum();
-        console.assert(zetajs.fromAny(v) === zetajs.uno.org.libreoffice.embindtest.Enum.E_2);
+        console.assert(v === zetajs.uno.org.libreoffice.embindtest.Enum.E_2);
         console.assert(test.isAnyEnum(v));
         console.assert(test.isAnyEnum(zetajs.uno.org.libreoffice.embindtest.Enum.E_2));
     }
     {
         const v = test.getAnyStruct();
-        console.assert(zetajs.fromAny(v).m1 === true);
-        console.assert(zetajs.fromAny(v).m2 === -12);
-        console.assert(zetajs.fromAny(v).m3 === -1234);
-        console.assert(zetajs.fromAny(v).m4 === 54321);
-        console.assert(zetajs.fromAny(v).m5 === -123456);
-        console.assert(zetajs.fromAny(v).m6 === 3456789012);
-        console.assert(zetajs.fromAny(v).m7 === -123456789n);
-        console.assert(zetajs.fromAny(v).m8 === 9876543210n);
-        console.assert(zetajs.fromAny(v).m9 === -10.25);
-        console.assert(zetajs.fromAny(v).m10 === 100.5);
-        console.assert(zetajs.fromAny(v).m11 === 'Ö');
-        console.assert(zetajs.fromAny(v).m12 === 'hä');
-        console.assert(zetajs.fromAny(v).m13.toString() === 'long');
-        console.assert(zetajs.fromAny(zetajs.fromAny(v).m14) === -123456);
-        console.assert(zetajs.fromAny(v).m15.length === 3);
-        console.assert(zetajs.fromAny(v).m15[0] === 'foo');
-        console.assert(zetajs.fromAny(v).m15[1] === 'barr');
-        console.assert(zetajs.fromAny(v).m15[2] === 'bazzz');
-        console.assert(zetajs.fromAny(v).m16 === zetajs.uno.org.libreoffice.embindtest.Enum.E_2);
-        console.assert(zetajs.fromAny(v).m17.m === -123456);
-        console.assert(zetajs.fromAny(v).m18.m1.m === 'foo');
-        console.assert(zetajs.fromAny(v).m18.m2 === -123456);
-        console.assert(zetajs.fromAny(zetajs.fromAny(v).m18.m3) === -123456);
-        console.assert(zetajs.fromAny(v).m18.m4.m === 'barr');
-        console.assert(zetajs.sameUnoObject(zetajs.fromAny(v).m19, test));
+        console.assert(v.m1 === true);
+        console.assert(v.m2 === -12);
+        console.assert(v.m3 === -1234);
+        console.assert(v.m4 === 54321);
+        console.assert(v.m5 === -123456);
+        console.assert(v.m6 === 3456789012);
+        console.assert(v.m7 === -123456789n);
+        console.assert(v.m8 === 9876543210n);
+        console.assert(v.m9 === -10.25);
+        console.assert(v.m10 === 100.5);
+        console.assert(v.m11 === 'Ö');
+        console.assert(v.m12 === 'hä');
+        console.assert(v.m13.toString() === 'long');
+        console.assert(v.m14 === -123456);
+        console.assert(v.m15.length === 3);
+        console.assert(v.m15[0] === 'foo');
+        console.assert(v.m15[1] === 'barr');
+        console.assert(v.m15[2] === 'bazzz');
+        console.assert(v.m16 === zetajs.uno.org.libreoffice.embindtest.Enum.E_2);
+        console.assert(v.m17.m === -123456);
+        console.assert(v.m18.m1.m === 'foo');
+        console.assert(v.m18.m2 === -123456);
+        console.assert(v.m18.m3 === -123456);
+        console.assert(v.m18.m4.m === 'barr');
+        console.assert(zetajs.sameUnoObject(v.m19, test));
         console.assert(test.isAnyStruct(v));
         console.assert(test.isAnyStruct(
             new zetajs.uno.org.libreoffice.embindtest.Struct(
@@ -331,18 +331,18 @@ Module.zetajs.then(function(zetajs) {
     }
     {
         const v = test.getAnyException();
-        console.assert(zetajs.fromAny(v).Message.startsWith('error'));
-        console.assert(zetajs.fromAny(v).Context === null);
-        console.assert(zetajs.fromAny(v).m1 === -123456);
-        console.assert(zetajs.fromAny(v).m2 === 100.5);
-        console.assert(zetajs.fromAny(v).m3 === 'hä');
+        console.assert(v.Message.startsWith('error'));
+        console.assert(v.Context === null);
+        console.assert(v.m1 === -123456);
+        console.assert(v.m2 === 100.5);
+        console.assert(v.m3 === 'hä');
         console.assert(test.isAnyException(v));
         console.assert(test.isAnyException(
             new zetajs.uno.org.libreoffice.embindtest.Exception(
                 {Message: 'error', m1: -123456, m2: 100.5, m3: 'hä'})));
     }
     {
-        const v = test.getAnyInterface();
+        const v = test.$precise.getAnyInterface();
         console.assert(zetajs.sameUnoObject(zetajs.fromAny(v), test));
         console.assert(test.isAnyInterface(v));
         console.assert(test.isAnyInterface(
@@ -462,7 +462,7 @@ Module.zetajs.then(function(zetajs) {
             zetajs.type.sequence(zetajs.type.enum(zetajs.uno.org.libreoffice.embindtest.Enum))]));
     }
     {
-        const v = test.getSequenceAny();
+        const v = test.$precise.getSequenceAny();
         console.assert(v.length === 3);
         console.assert(zetajs.fromAny(v[0]) === -123456);
         console.assert(zetajs.fromAny(v[1]) === undefined);
@@ -492,7 +492,7 @@ Module.zetajs.then(function(zetajs) {
         console.assert(test.isSequenceEnum(v));
     }
     {
-        const v = test.getSequenceStruct();
+        const v = test.$precise.getSequenceStruct();
         console.assert(v.length === 3);
         console.assert(v[0].m1 === true);
         console.assert(v[0].m2 === -12);
@@ -616,7 +616,7 @@ Module.zetajs.then(function(zetajs) {
         console.assert(v11.val === 'Ö');
         console.assert(v12.val === 'hä');
         console.assert(v13.val.toString() === 'long');
-        console.assert(zetajs.fromAny(v14.val) === -123456)
+        console.assert(v14.val === -123456)
         console.assert(v15.val.length === 3);
         console.assert(v15.val[0] === 'foo');
         console.assert(v15.val[1] === 'barr');
@@ -635,7 +635,7 @@ Module.zetajs.then(function(zetajs) {
         console.assert(v17.val.m11 === 'Ö');
         console.assert(v17.val.m12 === 'hä');
         console.assert(v17.val.m13.toString() === 'long');
-        console.assert(zetajs.fromAny(v17.val.m14) === -123456);
+        console.assert(v17.val.m14 === -123456);
         console.assert(v17.val.m15.length === 3);
         console.assert(v17.val.m15[0] === 'foo');
         console.assert(v17.val.m15[1] === 'barr');
@@ -644,7 +644,7 @@ Module.zetajs.then(function(zetajs) {
         console.assert(v17.val.m17.m === -123456);
         console.assert(v17.val.m18.m1.m === 'foo');
         console.assert(v17.val.m18.m2 === -123456);
-        console.assert(zetajs.fromAny(v17.val.m18.m3) === -123456);
+        console.assert(v17.val.m18.m3 === -123456);
         console.assert(v17.val.m18.m4.m === 'barr');
         console.assert(zetajs.sameUnoObject(v17.val.m19, test));
         console.assert(zetajs.sameUnoObject(v18.val, test));
@@ -655,7 +655,7 @@ Module.zetajs.then(function(zetajs) {
     } catch (e) {
         const exc = zetajs.catchUnoException(e);
         console.assert(zetajs.getAnyType(exc) == 'com.sun.star.uno.RuntimeException');
-        console.assert(zetajs.fromAny(exc).Message.startsWith('test'));
+        console.assert(exc.Message.startsWith('test'));
     }
     try {
         zetajs.throwUnoException(
@@ -667,16 +667,12 @@ Module.zetajs.then(function(zetajs) {
     } catch (e) {
         const exc = zetajs.catchUnoException(e);
         console.assert(zetajs.getAnyType(exc) == 'com.sun.star.lang.WrappedTargetException');
-        console.assert(zetajs.fromAny(exc).Message.startsWith('wrapped'));
-        console.assert(zetajs.sameUnoObject(zetajs.fromAny(exc).Context, test));
+        console.assert(exc.Message.startsWith('wrapped'));
+        console.assert(zetajs.sameUnoObject(exc.Context, test));
         console.assert(
-            zetajs.getAnyType(zetajs.fromAny(exc).TargetException) ==
-                'com.sun.star.uno.RuntimeException');
-        console.assert(
-            zetajs.fromAny(zetajs.fromAny(exc).TargetException).Message.startsWith('test'));
-        console.assert(
-            zetajs.sameUnoObject(
-                zetajs.fromAny(zetajs.fromAny(exc).TargetException).Context, test));
+            zetajs.getAnyType(exc.TargetException) == 'com.sun.star.uno.RuntimeException');
+        console.assert(exc.TargetException.Message.startsWith('test'));
+        console.assert(zetajs.sameUnoObject(exc.TargetException.Context, test));
     }
     console.assert(test.StringAttribute === 'hä');
     test.StringAttribute = 'foo';
@@ -723,17 +719,14 @@ Module.zetajs.then(function(zetajs) {
         [css.task.XJob, css.task.XJobExecutor, zetajs.uno.org.libreoffice.embindtest.XAttributes],
         objImpl);
     console.assert(
-        zetajs.fromAny(
-            obj.queryInterface(zetajs.type.interface(zetajs.uno.org.libreoffice.embindtest.XTest)))
+        obj.queryInterface(zetajs.type.interface(zetajs.uno.org.libreoffice.embindtest.XTest))
             === undefined);
     console.assert(
-        zetajs.sameUnoObject(
-            zetajs.fromAny(obj.queryInterface(zetajs.type.interface(css.uno.XInterface))), obj));
+        zetajs.sameUnoObject(obj.queryInterface(zetajs.type.interface(css.uno.XInterface)), obj));
     console.assert(
         zetajs.sameUnoObject(
-            zetajs.fromAny(
-                obj.queryInterface(
-                    zetajs.type.interface(zetajs.uno.org.libreoffice.embindtest.XAttributes))),
+            obj.queryInterface(
+                zetajs.type.interface(zetajs.uno.org.libreoffice.embindtest.XAttributes)),
             obj));
     test.passJob(obj);
     test.passJobExecutor(obj, false);


### PR DESCRIPTION
...instead of wrapped ones, which should simplify client code that interacts with such ANY values (witness the corresponding simplifications made here throughout the examples/ and test/ trees).  For special situations where wrapped representations are asked for, a $precise property is invented through which wrapped ANY representations are returned.