### PR TITLE
Use the qualified Module.ClassHandle

### DIFF
--- a/source/zeta.js
+++ b/source/zeta.js
@@ -175,7 +175,7 @@ Module.zetajs = new Promise(function (resolve, reject) {
           if (obj !== null) {
               const target = obj[getProxyTarget];
               const handle = target === undefined ? obj : target;
-              if (handle instanceof ClassHandle) {
+              if (handle instanceof Module.ClassHandle) {
                   if (type.toString() === 'com.sun.star.uno.XInterface') {
                       return handle;
                   }


### PR DESCRIPTION
...following up on
<https://git.libreoffice.org/core/+/1f24fd93763f0ef7f24a761ebee535dd5df33e24%5E%21> "Emscripten: Add ClassHandle to EXPORTED_RUNTIME_METHODS".  (For the standard builds, it doesn't seem to make a difference whether we use ClassHandle or Module.ClassHandle here, but for some experimental Qt6 builds of mine, the worker thread importing this code was not able to resolve plain ClassHandle by itself, for whatever exact reason.)